### PR TITLE
Change pyspark to spark-submit which is required for spark 2.0+.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,5 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean
 
-ENTRYPOINT ["pyspark"]
+ENTRYPOINT ["spark-submit"]
 CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -5,14 +5,31 @@ PySpark docker container based on OpenJDK 8 and Miniconda 3
 [![](https://images.microbadger.com/badges/image/godatadriven/pyspark.svg)](https://microbadger.com/images/godatadriven/pyspark "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/godatadriven/pyspark.svg)](https://microbadger.com/images/godatadriven/pyspark "Get your own version badge on microbadger.com") 
 
 ## Running the container
-By default pyspark --help is run:
+By default spark-submit --help is run:
 
-```
+```bash
 docker run godatadriven/pyspark 
 ```
 
 To run your own job, make the job accessible through a volume and pass the necessary arguments:
 
-```
+```bash
 docker run -v /local_folder:/job godatadriven/pyspark [options] /job/<python file> [app arguments]
+```
+
+### Samples
+
+The folder samples contain some PySpark jobs, how to obtain a spark session and crunch some data. The current directory is mapped as /job. So run the docker command from the root directory of this project.
+
+```bash
+# Self word counter:
+docker run -v $(pwd):/job godatadriven/pyspark /job/samples/word_counter.py
+
+# Self word counter with spark extra options
+docker run -v $(pwd):/job godatadriven/pyspark \
+	--name "I count myself" \
+	--master "local[1]" \
+	--conf "spark.ui.showConsoleProgress=True" \
+	--conf "spark.ui.enabled=False" \
+	/job/samples/word_counter.py "jobSampleArgument1"
 ```

--- a/samples/word_counter.py
+++ b/samples/word_counter.py
@@ -1,0 +1,20 @@
+# This file is called word_counter.py
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+spark = SparkSession.builder.getOrCreate()
+
+df = spark.read.text(paths='/job/samples/word_counter.py')
+# Replace code chars with spaces
+df = df.withColumn('value', F.regexp_replace('value', '\W', ' '))
+# Split on spaces
+df = df.select(F.explode(F.split('value', ' ')).alias('word'))
+# Filter min length
+df = df.where(F.length('word') > 0)
+# Group by occurence and order
+agg = (df.groupBy('word')
+         .count()
+         .sort('count', ascending=False)
+      )
+# Print top result
+agg.limit(5).show()


### PR DESCRIPTION
When I try to run a pyspark job I get this error: 

```bash
Running python applications through 'pyspark' is not supported as of Spark 2.0.
Use ./bin/spark-submit <python file>
```
I changed the command to spark-submit and added a nice working example